### PR TITLE
change set database 29 lesson

### DIFF
--- a/one-by-one/lesson-29.md
+++ b/one-by-one/lesson-29.md
@@ -29,7 +29,7 @@ require 'sinatra'
 require 'sinatra/reloader'
 require 'sinatra/activerecord'
 
-set :database, "sqlite3.my_database.db"
+set :database, {adapter: "sqlite3", database: "my_database.db"}
 
 get '/' do
   erb :index

--- a/rubyschool-notes-04.md
+++ b/rubyschool-notes-04.md
@@ -427,7 +427,7 @@ require 'sinatra'
 require 'sinatra/reloader'
 require 'sinatra/activerecord'
 
-set :database, "sqlite3.my_database.db"
+set :database, {adapter: "sqlite3", database: 'my_database.db'}
 
 get '/' do
   erb :index


### PR DESCRIPTION
set :database, "sqlite3.my_database.db"  --- rake db:migrate не отрабатывает эту строку
set :database, {adapter: "sqlite3", database: "my_database.db"} ----- а эту нормально проходит